### PR TITLE
Add option to turn off Pretty Output

### DIFF
--- a/lib/coffeelint.rb
+++ b/lib/coffeelint.rb
@@ -59,12 +59,14 @@ module Coffeelint
     end
   end
 
-  def self.run_test(file, config = {}, pretty_output = true)
+  def self.run_test(file, config = {})
+    pretty_output = config.has_key?(:pretty_output) ? config.delete(:pretty_output) : true
     result = Coffeelint.lint_file(file, config)
     Coffeelint.display_test_results(file, result, pretty_output)
   end
 
-  def self.run_test_suite(directory, config = {}, pretty_output = true)
+  def self.run_test_suite(directory, config = {})
+    pretty_output = config.has_key?(:pretty_output) ? config.delete(:pretty_output) : true
     success = true
     Coffeelint.lint_dir(directory, config) do |name, errors|
       result = Coffeelint.display_test_results(name, errors, pretty_output)


### PR DESCRIPTION
Otherwise, when running Coffelint in a pipe, for example, there is a need to duplicate the results output functionality already present in the Gem to remove the colours and unicode characters.
