### PR TITLE
Fix typo in Coffeelint.display_test_results

### DIFF
--- a/lib/coffeelint.rb
+++ b/lib/coffeelint.rb
@@ -52,7 +52,7 @@ module Coffeelint
       puts "  #{bad} " + Coffeelint.red(name, pretty_output)
       errors.each do |error|
         print "     #{bad} "
-        print CoffeeLint.red(error["lineNumber"], pretty_output)
+        print Coffeelint.red(error["lineNumber"], pretty_output)
         puts ": #{error["message"]}, #{error["context"]}."
       end
       return false


### PR DESCRIPTION
An error gets thrown when reporting any errors - this is due to a typo. Fixed it in my fork, but would be nice to get this merged back into your master. Let me know.

Cheers,

Eric Halvorsen
