### PR TITLE
Fix --file option to allow a file to be passed to it

### DIFF
--- a/bin/coffeelint.rb
+++ b/bin/coffeelint.rb
@@ -30,7 +30,7 @@ opt_parser = OptionParser.new do |opts|
 =end
 
 
-  opts.on "-f", "--file", "Specify a custom configuration file." do |f|
+  opts.on "-f FILE", "--file FILE", "Specify a custom configuration file." do |f|
     linter_options[:config_file] = f
   end
 


### PR DESCRIPTION
Fixes an issue where linter_options contains `{ config_file: true }` when trying to pass a configuration file.
