### PR TITLE
Check if Rails::Railtie class is defined

### DIFF
--- a/lib/coffeelint.rb
+++ b/lib/coffeelint.rb
@@ -4,7 +4,7 @@ require 'coffee-script'
 require 'json'
 
 module Coffeelint
-  require 'coffeelint/railtie' if defined?(Rails)
+  require 'coffeelint/railtie' if defined?(Rails::Railtie)
 
   def self.path()
     @path ||= File.expand_path('../../coffeelint/lib/coffeelint.js', __FILE__)


### PR DESCRIPTION
Old versions of Rails don't support Railtie. Which breaks simply requiring `coffeelint`.

Usually gems with railties suggest users do an explicit `railtie` require in their Gemfile like.

``` ruby
# Gemfile
gem "coffeelint", require: "coffeelint/railtie"
```

But that would be a backwards incompatible change.
