### PR TITLE
Remove deprecated railtie_name

### DIFF
--- a/lib/coffeelint/railtie.rb
+++ b/lib/coffeelint/railtie.rb
@@ -2,8 +2,6 @@ require 'coffeelint'
 require 'rails'
 module Coffeelint
   class Railtie < Rails::Railtie
-    railtie_name :coffeelint
-
     rake_tasks do
       load 'tasks/coffeelint.rake'
     end


### PR DESCRIPTION
Fixes deprecation warning on boot.

```
DEPRECATION WARNING: railtie_name is deprecated and has no effect.
```
