### PR TITLE
Allow using custom version of coffeelint.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Coffeelint.run_test_suite(directory, :config_file => 'coffeelint_config.json')
 
 Then it will load the config options from that file.
 
+To use a local version of coffeelint instead of the one bundled with the gem, You can set the path with `Coffeelint.set_path(/path/to/coffeelint.js)`
+
 Additionally, if you are using rails you also get the rake task:
 
     rake coffeelint

--- a/lib/coffeelint.rb
+++ b/lib/coffeelint.rb
@@ -7,6 +7,10 @@ require 'json'
 module Coffeelint
   require 'coffeelint/railtie' if defined?(Rails::Railtie)
 
+  def self.set_path(custom_path)
+    @path = custom_path
+  end
+
   def self.path()
     @path ||= File.expand_path('../../coffeelint/lib/coffeelint.js', __FILE__)
   end

--- a/lib/coffeelint/version.rb
+++ b/lib/coffeelint/version.rb
@@ -1,3 +1,3 @@
 module Coffeelint
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end


### PR DESCRIPTION
I wanted to use the latest version of coffeelint, but I couldn't get the submodule to work correctly, so I added this method to use a different version of coffeelint (from npm). This will make it easier to follow updates of coffeelint without changing the gem.
