### PR TITLE
Fixes #21. Updates code to new syntax. Locks rspec version.

### DIFF
--- a/coffeelint.gemspec
+++ b/coffeelint.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "json"
   gem.add_dependency "execjs"
 
-  gem.add_development_dependency 'rspec'
+  gem.add_development_dependency 'rspec', '~> 3.1.0'
   gem.add_development_dependency 'rake'
 end


### PR DESCRIPTION
Fixes color_enabled config incompatibility. Locks rspec version to minor updates to make sure this doesn't happen again, updates syntax from should to expect.
