### PR TITLE
disallow coffee-script-source v1.9 dependency

### DIFF
--- a/coffeelint.gemspec
+++ b/coffeelint.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
+  gem.add_dependency 'coffee-script-source', '< 1.9'
   gem.add_dependency "coffee-script"
   gem.add_dependency "json"
   gem.add_dependency "execjs"


### PR DESCRIPTION
Using coffee-script-source v1.9.0 results in bogus output regarding whitespace checks. One whitespace is interpreted as two.

e.g.:
```
✗ #2: Colon assignment without proper spacing. Incorrect spacing around column 9.
Expected left: 0, right: 1.
Got left: 0, right: 2..
```