### PR TITLE
Fix spelling of ENV['COFFEELINT_CONFIG'] variable

### DIFF
--- a/lib/tasks/coffeelint.rake
+++ b/lib/tasks/coffeelint.rake
@@ -3,7 +3,7 @@ task :coffeelint do
   conf = {}
 
   config_file = [].tap {|files|
-    files << ENV['COFFEELNT_CONFIG'] if ENV['COFFEELENT_CONFIG']
+    files << ENV['COFFEELINT_CONFIG'] if ENV['COFFEELINT_CONFIG']
     files << 'config/coffeelint.json'
     if ENV['HOME']
       files << "#{ENV['HOME']}/coffeelint.json"


### PR DESCRIPTION
Both ENV variable spellings differed from the intentional spelling, which was noted in the original commit message.