### PR TITLE
Centralize config file handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ Coffeelint.run_test_suite(directory, :config_file => 'coffeelint_config.json')
 
 Then it will load the config options from that file.
 
+Alternatively you can create a config file in your project, coffeelint will load these by default:
+
+* coffeelint.json
+* .coffeelint.json
+* config/coffeelint.json
+* config/.coffeelint.json
+
 To use a local version of coffeelint instead of the one bundled with the gem, You can set the path with `Coffeelint.set_path(/path/to/coffeelint.js)`
 
 Additionally, if you are using rails you also get the rake task:

--- a/lib/coffeelint.rb
+++ b/lib/coffeelint.rb
@@ -1,8 +1,8 @@
 require "coffeelint/version"
+require 'coffeelint/config'
 require 'coffeelint/cmd'
 require 'execjs'
 require 'coffee-script'
-require 'json'
 
 module Coffeelint
   require 'coffeelint/railtie' if defined?(Rails::Railtie)
@@ -44,10 +44,8 @@ module Coffeelint
   end
 
   def self.lint(script, config = {})
-    if !config[:config_file].nil?
-      fname = config.delete(:config_file)
-      config.merge!(JSON.parse(File.read(fname)))
-    end
+    fname = config.fetch(:config_file, CoffeeLint::Config.locate)
+    config.merge!(CoffeeLint::Config.parse(fname)) unless fname.nil?
     Coffeelint.context.call('window.coffeelint.lint', script, config)
   end
 

--- a/lib/coffeelint/config.rb
+++ b/lib/coffeelint/config.rb
@@ -6,12 +6,9 @@ module CoffeeLint
     def self.locate
       locations = default_locations
 
+      # handle environment variables
       locations << ENV['COFFEELINT_CONFIG'] if ENV['COFFEELINT_CONFIG']
-
-      if ENV['HOME']
-        locations << "#{ENV['HOME']}/coffeelint.json"
-        locations << "#{ENV['HOME']}/.coffeelint.json"
-      end
+      locations += config_files_in_path(ENV['HOME']) if ENV['HOME']
 
       locations.compact.detect { |file| File.exists?(file) }
     end
@@ -21,14 +18,25 @@ module CoffeeLint
       JSON.parse(File.read(file_name))
     end
 
+    # Config files CoffeeLint will look for.
     def self.default_locations
+      config_files + config_files_in_path('config')
+    end
+    private_class_method :default_locations
+
+    # Maps config file names in given path/directory.
+    def self.config_files_in_path(path)
+      config_files.map { |file| File.join([*path, file].reject { |p| p.nil? || p.empty?}) }
+    end
+    private_class_method :config_files_in_path
+
+    # Config file names CoffeeLint will look for.
+    def self.config_files
       %w(
         coffeelint.json
         .coffeelint.json
-        config/coffeelint.json
-        config/.coffeelint.json
       )
     end
-    private_class_method :default_locations
+    private_class_method :config_files
   end
 end

--- a/lib/coffeelint/config.rb
+++ b/lib/coffeelint/config.rb
@@ -1,0 +1,34 @@
+require 'json'
+
+module CoffeeLint
+  class Config
+    # Looks for existing config files and returns the first match.
+    def self.locate
+      locations = default_locations
+
+      locations << ENV['COFFEELINT_CONFIG'] if ENV['COFFEELINT_CONFIG']
+
+      if ENV['HOME']
+        locations << "#{ENV['HOME']}/coffeelint.json"
+        locations << "#{ENV['HOME']}/.coffeelint.json"
+      end
+
+      locations.compact.detect { |file| File.exists?(file) }
+    end
+
+    # Parses a given JSON file to a Hash.
+    def self.parse(file_name)
+      JSON.parse(File.read(file_name))
+    end
+
+    def self.default_locations
+      %w(
+        coffeelint.json
+        .coffeelint.json
+        config/coffeelint.json
+        config/.coffeelint.json
+      )
+    end
+    private_class_method :default_locations
+  end
+end

--- a/lib/coffeelint/config.rb
+++ b/lib/coffeelint/config.rb
@@ -26,7 +26,7 @@ module CoffeeLint
 
     # Maps config file names in given path/directory.
     def self.config_files_in_path(path)
-      config_files.map { |file| File.join([*path, file].reject { |p| p.nil? || p.empty?}) }
+      config_files.map { |file| File.join([*path, file].reject { |p| p.nil? || p.empty? }) }
     end
     private_class_method :config_files_in_path
 

--- a/lib/coffeelint/config.rb
+++ b/lib/coffeelint/config.rb
@@ -26,7 +26,7 @@ module CoffeeLint
 
     # Maps config file names in given path/directory.
     def self.config_files_in_path(path)
-      config_files.map { |file| File.join([*path, file].reject { |p| p.nil? || p.empty? }) }
+      config_files.map { |file| File.join([*path, file].compact.reject(&:empty?)) }
     end
     private_class_method :config_files_in_path
 

--- a/lib/coffeelint/config.rb
+++ b/lib/coffeelint/config.rb
@@ -7,8 +7,8 @@ module CoffeeLint
       locations = default_locations
 
       # handle environment variables
-      locations << ENV['COFFEELINT_CONFIG'] if ENV['COFFEELINT_CONFIG']
-      locations += config_files_in_path(ENV['HOME']) if ENV['HOME']
+      locations.push(ENV['COFFEELINT_CONFIG']) if ENV['COFFEELINT_CONFIG']
+      locations.concat(config_files_in_path(ENV['HOME'])) if ENV['HOME']
 
       locations.compact.detect { |file| File.exists?(file) }
     end

--- a/lib/tasks/coffeelint.rake
+++ b/lib/tasks/coffeelint.rake
@@ -1,17 +1,5 @@
 desc "lint application javascript"
 task :coffeelint do
-  conf = {}
-
-  config_file = [].tap {|files|
-    files << ENV['COFFEELINT_CONFIG'] if ENV['COFFEELINT_CONFIG']
-    files << 'config/coffeelint.json'
-    if ENV['HOME']
-      files << "#{ENV['HOME']}/coffeelint.json"
-      files << "#{ENV['HOME']}/.coffeelint.json"
-    end
-  }.compact.detect {|file| File.exists?(file) }
-
-  conf[:config_file] = config_file if config_file
-  success = Coffeelint.run_test_suite('app', conf) and Coffeelint.run_test_suite('spec', conf)
+  success = Coffeelint.run_test_suite('app') and Coffeelint.run_test_suite('spec')
   fail "Lint!" unless success
 end

--- a/spec/assets/.coffeelint.json
+++ b/spec/assets/.coffeelint.json
@@ -1,0 +1,5 @@
+{
+  "max_line_length": {
+    "value": 120
+  }
+}

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -26,7 +26,7 @@ module CoffeeLint
           expect(Config.locate).to eq('coffeelint.json')
         end
 
-        it 'tries to locate in ENV[\'HOME\']' do
+        it 'tries to locate config files in ENV[\'HOME\']' do
           ENV['HOME'] = '~/coffeescript'
 
           allow(File).to receive(:exists?).with('~/coffeescript/.coffeelint.json').and_return(true)
@@ -39,6 +39,25 @@ module CoffeeLint
       it 'should parse a given JSON file' do
         expect(Config.parse(File.join(File.dirname(__FILE__), 'assets/.coffeelint.json'))).
           to eq({"max_line_length" => {"value" => 120}})
+      end
+    end
+
+    context 'private class methods' do
+      describe '.config_files_in_path' do
+        it 'ignores empty path segments' do
+          result = %w(coffeelint.json .coffeelint.json)
+          expect(Config.send(:config_files_in_path, '')).to eq(result)
+          expect(Config.send(:config_files_in_path, [])).to eq(result)
+          expect(Config.send(:config_files_in_path, [''])).to eq(result)
+        end
+
+        it 'builds usefull path segements' do
+          result = %w(config/coffeelint.json config/.coffeelint.json)
+          expect(Config.send(:config_files_in_path, 'config')).to eq(result)
+          expect(Config.send(:config_files_in_path, ['config'])).to eq(result)
+          expect(Config.send(:config_files_in_path, ['coffeescript', 'config'])).
+            to eq(%w(coffeescript/config/coffeelint.json coffeescript/config/.coffeelint.json))
+        end
       end
     end
   end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+module CoffeeLint
+  describe Config do
+    describe '.locate' do
+      before(:each) { allow(File).to receive(:exists?) { false } }
+
+      it 'returns nil if no config file could be located' do
+        expect(Config.locate).to eq(nil)
+      end
+
+      context 'default locations' do
+        %w(coffeelint.json .coffeelint.json config/coffeelint.json config/.coffeelint.json).each do |config_file|
+          it "tries to locate #{config_file}" do
+            allow(File).to receive(:exists?).with(config_file).and_return(true)
+            expect(Config.locate).to eq(config_file)
+          end
+        end
+      end
+
+      context 'environment variables' do
+        it 'tries to locate ENV[\'COFFEELINT_CONFIG\']' do
+          ENV['COFFEELINT_CONFIG'] = 'coffeelint.json'
+
+          allow(File).to receive(:exists?).with('coffeelint.json').and_return(true)
+          expect(Config.locate).to eq('coffeelint.json')
+        end
+
+        it 'tries to locate ENV[\'HOME\']' do
+          ENV['HOME'] = 'coffeelint.json'
+
+          allow(File).to receive(:exists?).with('coffeelint.json').and_return(true)
+          expect(Config.locate).to eq('coffeelint.json')
+        end
+      end
+    end
+
+    describe '.parse' do
+      it 'should parse a given JSON file' do
+        expect(Config.parse(File.join(File.dirname(__FILE__), 'assets/.coffeelint.json'))).
+          to eq({"max_line_length" => {"value" => 120}})
+      end
+    end
+  end
+end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -26,11 +26,11 @@ module CoffeeLint
           expect(Config.locate).to eq('coffeelint.json')
         end
 
-        it 'tries to locate ENV[\'HOME\']' do
-          ENV['HOME'] = 'coffeelint.json'
+        it 'tries to locate in ENV[\'HOME\']' do
+          ENV['HOME'] = '~/coffeescript'
 
-          allow(File).to receive(:exists?).with('coffeelint.json').and_return(true)
-          expect(Config.locate).to eq('coffeelint.json')
+          allow(File).to receive(:exists?).with('~/coffeescript/.coffeelint.json').and_return(true)
+          expect(Config.locate).to eq('~/coffeescript/.coffeelint.json')
         end
       end
     end


### PR DESCRIPTION
Hey Zachary,

I moved the config file handling (locating and parsing the file) into a separate class.

The CoffeeLint.lint method now uses the new .locate and .parse methods by default, 
unless a specific :config_file options was given. This simplifies the usage and configuration 
of the coffeelint bin and rake task.

Also third party gems like e.g. pronto-coffeelint don't have to duplicate the lookup behavior.

I would like to see this merged ^^ 

What do you think about it?