### PR TITLE
Fix assignment of gem files in the gemspec.

### DIFF
--- a/coffeelint.gemspec
+++ b/coffeelint.gemspec
@@ -13,9 +13,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/zipcodeman/coffeelint-ruby"
   gem.licenses      = ["MIT"]
 
-  gem.files         = `git ls-files`.split($/)
-  gem.files        -= ['bin/coffeelint']
-  gem.files        << 'coffeelint/lib/coffeelint.js'
+  gem.files         = `git ls-files`.split($/) + %w(coffeelint/lib/coffeelint.js) - %w(bin/coffeelint)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]


### PR DESCRIPTION
While depending on a local checkout (during development), 
bundle install reported an invalid gemspec:
 
```
coffeelint at (...) did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  ["coffeelint/lib/coffeelint.js"] are not files
```

```
gem.files        << 'coffeelint/lib/coffeelint.js'
```
Since rubygems does not allow to append to the files accessor (http://guides.rubygems.org/specification-reference/#files),  the coffeelint/lib/coffeelint.js was not available during install. 
