### PR TITLE
Fix for issue #37 coffeelint rake task fix

### DIFF
--- a/lib/coffeelint.rb
+++ b/lib/coffeelint.rb
@@ -112,6 +112,6 @@ module Coffeelint
       errors_count += errors.count
       result = Coffeelint.display_test_results(name, errors, pretty_output)
     end
-    exit errors_count
+    errors_count
   end
 end

--- a/lib/tasks/coffeelint.rake
+++ b/lib/tasks/coffeelint.rake
@@ -1,5 +1,5 @@
 desc "lint application javascript"
 task :coffeelint do
-  success = Coffeelint.run_test_suite('app') and Coffeelint.run_test_suite('spec')
+  success = (Coffeelint.run_test_suite('app') == 0) and (Coffeelint.run_test_suite('spec') == 0)
   fail "Lint!" unless success
 end


### PR DESCRIPTION
`Coffeelint.run_test_suite` now returns the number of failed tests.  If all tests pass 0 is returned which is interpreted as false by ruby.  Changing the task to check the result of `run_test_suite` against 0 to determine success of the task.