### PR TITLE
Updates coffeelint to 1.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Coffeelint [![Build Status](https://travis-ci.org/zmbush/coffeelint-ruby.svg?branch=master)](https://travis-ci.org/zmbush/coffeelint-ruby) [![Gem Version](https://badge.fury.io/rb/coffeelint.png)](http://badge.fury.io/rb/coffeelint)
 
-Using coffeelint version: v1.14.0
+Using coffeelint version: v1.16.0
 
 Coffeelint is a set of simple ruby bindings for [coffeelint](https://github.com/clutchski/coffeelint).
 

--- a/coffeelint.gemspec
+++ b/coffeelint.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency "execjs"
 
   gem.add_development_dependency 'rspec', '~> 3.1.0'
-  gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'rake', '~>11.3.0'
 end


### PR DESCRIPTION
* `rake 12.0.0` raises this error `NoMethodError: undefined method `last_comment' for #<Rake::Application:0x00556216f970b8>`
